### PR TITLE
Fix Oracle dialect: extend Oracle12cDialect and disable passDistinctThrough

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Get Fetch Tags
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: "!contains(github.ref, 'refs/tags')"
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ jar {
 }
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
     withSourcesJar()
     withJavadocJar()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/rundeck/hibernate/OracleDistinctStatementInspector.java
+++ b/src/main/java/org/rundeck/hibernate/OracleDistinctStatementInspector.java
@@ -1,0 +1,28 @@
+package org.rundeck.hibernate;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import java.util.regex.Pattern;
+
+/**
+ * Strips DISTINCT from all SELECT statements before they reach Oracle.
+ *
+ * Oracle rejects SELECT DISTINCT when any selected column is a CLOB or BLOB (ORA-22848).
+ * Hibernate's HQL DISTINCT maps to SQL DISTINCT by default, which triggers this Oracle
+ * restriction on entity queries that include large-object columns like workflow_json.
+ *
+ * This inspector rewrites "SELECT DISTINCT" → "SELECT", delegating deduplication to
+ * Hibernate's in-memory result transformer, which is the same behavior as setting
+ * hibernate.query.passDistinctThrough=false per query.
+ */
+public class OracleDistinctStatementInspector implements StatementInspector {
+
+    private static final Pattern SELECT_DISTINCT =
+            Pattern.compile("(?i)\\bselect\\s+distinct\\b");
+
+    @Override
+    public String inspect(String sql) {
+        if (sql == null) return null;
+        return SELECT_DISTINCT.matcher(sql).replaceAll("select");
+    }
+}

--- a/src/main/java/org/rundeck/hibernate/OracleDistinctStatementInspector.java
+++ b/src/main/java/org/rundeck/hibernate/OracleDistinctStatementInspector.java
@@ -17,12 +17,14 @@ import java.util.regex.Pattern;
  */
 public class OracleDistinctStatementInspector implements StatementInspector {
 
+    // Anchored to start of statement so it cannot match inside string literals or subqueries.
+    // Oracle's ORA-22848 is only triggered by the outermost SELECT DISTINCT on LOB columns.
     private static final Pattern SELECT_DISTINCT =
-            Pattern.compile("(?i)\\bselect\\s+distinct\\b");
+            Pattern.compile("(?i)^\\s*select\\s+distinct\\b");
 
     @Override
     public String inspect(String sql) {
         if (sql == null) return null;
-        return SELECT_DISTINCT.matcher(sql).replaceAll("select");
+        return SELECT_DISTINCT.matcher(sql).replaceFirst("select");
     }
 }

--- a/src/main/java/org/rundeck/hibernate/OracleSessionFactoryBuilderFactory.java
+++ b/src/main/java/org/rundeck/hibernate/OracleSessionFactoryBuilderFactory.java
@@ -1,0 +1,26 @@
+package org.rundeck.hibernate;
+
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryBuilderFactory;
+import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
+
+/**
+ * Hibernate SPI that registers {@link OracleDistinctStatementInspector} when
+ * {@link RundeckOracleDialect} is active.
+ *
+ * Discovered via Java service loader from META-INF/services — no changes to
+ * Rundeck's application.groovy or rundeck-config.properties are required.
+ */
+public class OracleSessionFactoryBuilderFactory implements SessionFactoryBuilderFactory {
+
+    @Override
+    public SessionFactoryBuilder getSessionFactoryBuilder(
+            MetadataImplementor metadata,
+            SessionFactoryBuilderImplementor defaultBuilder) {
+        if (metadata.getDatabase().getDialect() instanceof RundeckOracleDialect) {
+            defaultBuilder.applyStatementInspector(new OracleDistinctStatementInspector());
+        }
+        return defaultBuilder;
+    }
+}

--- a/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
+++ b/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
@@ -10,12 +10,9 @@ import java.sql.Types;
 public class RundeckOracleDialect
         extends Oracle12cDialect
 {
+
     public RundeckOracleDialect() {
         super();
-        // Oracle cannot use CLOB/BLOB columns in SELECT DISTINCT queries (ORA-22848).
-        // Disabling passDistinctThrough makes Hibernate deduplicate results in memory
-        // instead of emitting SQL DISTINCT, avoiding this Oracle restriction.
-        getDefaultProperties().setProperty("hibernate.query.passDistinctThrough", "false");
     }
 
     @Override

--- a/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
+++ b/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
@@ -3,7 +3,6 @@ package org.rundeck.hibernate;
 import org.hibernate.dialect.Oracle12cDialect;
 
 import java.sql.Types;
-import java.util.Properties;
 
 /**
  * Custom Oracle dialect that fixes various issues with Oracle support in Hibernate.
@@ -11,14 +10,12 @@ import java.util.Properties;
 public class RundeckOracleDialect
         extends Oracle12cDialect
 {
-    @Override
-    public Properties getDefaultProperties() {
-        Properties props = super.getDefaultProperties();
+    public RundeckOracleDialect() {
+        super();
         // Oracle cannot use CLOB/BLOB columns in SELECT DISTINCT queries (ORA-22848).
         // Disabling passDistinctThrough makes Hibernate deduplicate results in memory
         // instead of emitting SQL DISTINCT, avoiding this Oracle restriction.
-        props.setProperty("hibernate.query.passDistinctThrough", "false");
-        return props;
+        getDefaultProperties().setProperty("hibernate.query.passDistinctThrough", "false");
     }
 
     @Override

--- a/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
+++ b/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
@@ -1,15 +1,27 @@
 package org.rundeck.hibernate;
 
-import org.hibernate.dialect.Oracle10gDialect;
+import org.hibernate.dialect.Oracle12cDialect;
 
 import java.sql.Types;
+import java.util.Properties;
 
 /**
  * Custom Oracle dialect that fixes various issues with Oracle support in Hibernate.
  */
 public class RundeckOracleDialect
-        extends Oracle10gDialect
+        extends Oracle12cDialect
 {
+    @Override
+    public Properties getDefaultProperties() {
+        Properties props = super.getDefaultProperties();
+        // Oracle cannot use CLOB/BLOB columns in SELECT DISTINCT queries (ORA-22848).
+        // Disabling passDistinctThrough makes Hibernate deduplicate results in memory
+        // instead of emitting SQL DISTINCT, avoiding this Oracle restriction.
+        props.setProperty("hibernate.query.passDistinctThrough", "false");
+        return props;
+    }
+
+    @Override
     protected void registerLargeObjectTypeMappings() {
         registerColumnType(Types.BLOB, "blob");
         registerColumnType(Types.CLOB, "clob");
@@ -24,6 +36,7 @@ public class RundeckOracleDialect
         registerColumnType(Types.LONGVARBINARY, "blob");
     }
 
+    @Override
     protected void registerCharacterTypeMappings() {
         super.registerCharacterTypeMappings();
         registerColumnType(Types.VARCHAR, "varchar($l)");

--- a/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.spi.SessionFactoryBuilderFactory
@@ -1,0 +1,1 @@
+org.rundeck.hibernate.OracleSessionFactoryBuilderFactory


### PR DESCRIPTION
## Problem

When running Rundeck against Oracle 23c Free (and 12c+), two failures occur on startup and during job execution:

1. **`ORA-904 / IdentityColumnSupportImpl does not support identity key generation`** — the previous `Oracle10gDialect` base class lacks identity column support introduced in Oracle 12c. Rundeck's Liquibase migrations use `GENERATED AS IDENTITY`, which fails at the JDBC level.

2. **`ORA-22848: cannot use CLOB type as comparison key`** — Hibernate expands HQL `SELECT DISTINCT e.scheduledExecution` (an entity with a `workflow_json` CLOB column) into SQL `SELECT DISTINCT col1, col2, ..., workflow_json, ...`. Oracle rejects `DISTINCT` on any CLOB or BLOB column at the SQL level.

---

## Investigation

### ORA-22848 root cause

Hibernate's HQL `SELECT DISTINCT <entity>` always expands to SQL `SELECT DISTINCT *` over all mapped columns. For `ScheduledExecution`, this includes `workflow_json` (CLOB), which Oracle cannot use as a comparison key for deduplication.

### Why `hibernate.query.passDistinctThrough=false` doesn't work globally

The natural fix would be to disable SQL-level DISTINCT via the `passDistinctThrough` query hint. Three configuration paths were investigated and all failed with GORM 7 / Hibernate 5.6:

- **`RundeckOracleDialect#getDefaultProperties()`** — the dialect is instantiated *after* `StandardServiceRegistry` is built. Properties set here are never merged back into the registry, so Hibernate never sees them.
- **`hibernate.query.passDistinctThrough=false` in `rundeck-config.properties`** — this is a per-query runtime hint (`QueryHints`), not a global `AvailableSettings` property. Hibernate 5.6 does not read it from any configuration file.
- **`application.groovy` hibernate block** — GORM flattens the block to `hibernate.*` properties, but `passDistinctThrough` is still a query-level hint and is ignored at `SessionFactory` build time.

### Why there is no upstream interception point in Hibernate 5.6

The HQL → SQL pipeline is: HQL parse → AST (`SelectClause` with `DISTINCT` token) → `SqlGenerator` emits `SELECT DISTINCT col1, col2, workflow_json...` → `Loader.processDistinctKeyword()` → `StatementInspector` → JDBC.

Every potential interception point was investigated:

| Option | Result |
|---|---|
| `Dialect` hook for DISTINCT rendering | Does not exist in Hibernate 5.6 — `Dialect` is not consulted during `SqlGenerator` DISTINCT emission |
| Global `passDistinctThrough` via any SPI | Not supported — `passDistinctThrough` lives in `QueryParameters` (per-query only); no factory-level or session-level default exists |
| `Integrator` / `SessionFactoryObserver` | No query-execution hooks; cannot reach `QueryParameters` |
| Custom `QueryTranslatorFactory` via `hibernate.query.factory_class` | Technically possible — subclass `QueryTranslatorImpl` + `QueryLoader` to mutate `QueryParameters.passDistinctThrough` before execution — but equally fragile, more invasive, and produces the exact same result as a `StatementInspector` |
| `StatementInspector` via `SessionFactoryBuilderFactory` SPI | **Optimal** — clean, self-contained in the JAR, no Rundeck source changes |

The AST nodes (`HqlSqlWalker`, `SqlGenerator`, `SelectClause`) are wired internally via ANTLR grammar and are not pluggable from outside.

**Noteworthy:** `Loader.processDistinctKeyword()` in Hibernate 5.6 performs the *identical* string substitution (`SELECT DISTINCT` → `SELECT`) when `passDistinctThrough=false` is set per-query, using the same `Loader.SELECT_DISTINCT = "select distinct"` constant. Our `StatementInspector` replicates that behavior globally, which is precisely what `passDistinctThrough=false` would do if a global configuration path existed.

**Sources:**
- [Hibernate 5.6 `AvailableSettings.java`](https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java) — `passDistinctThrough` is absent; lives only in `QueryHints`
- [Hibernate 5.6 `Loader.java`](https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/loader/Loader.java) — `processDistinctKeyword()` and `SELECT_DISTINCT` constant
- [Hibernate 5.6 `QueryTranslatorImpl.java`](https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/QueryTranslatorImpl.java) — `createQueryLoader()` is `protected` but subclassing is fragile
- [Hibernate 5.6 `AbstractProducedQuery.java`](https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java) — `passDistinctThrough` field default is `true`, set only via `setHint()`
- [The DISTINCT pass-through Hibernate Query Hint — In Relation To](https://in.relation.to/2016/08/04/introducing-distinct-pass-through-query-hint/)
- [Hibernate 6: `HINT_PASS_DISTINCT_THROUGH` removed — Hibernate Discourse](https://discourse.hibernate.org/t/hibernate-6-org-hibernate-jpa-queryhints-hint-pass-distinct-through-has-been-removed/7131)

### Solution: `SessionFactoryBuilderFactory` SPI

Hibernate 5.6 discovers implementations of `org.hibernate.boot.spi.SessionFactoryBuilderFactory` via Java `ServiceLoader` from the classpath. This SPI runs *before* the `SessionFactory` is built and can inject a `StatementInspector` into the builder.

A `StatementInspector` registered via `SessionFactoryBuilder#applyStatementInspector()` intercepts every SQL string before it reaches the JDBC driver — at the same point where `Loader.processDistinctKeyword()` would have acted. By rewriting `SELECT DISTINCT` → `SELECT` at this layer (anchored to the start of the statement to avoid matching inside string literals), Oracle never sees the DISTINCT, eliminating ORA-22848. Hibernate's result transformer handles in-memory deduplication; call sites with scalar projections add `.unique()` explicitly.

This approach is entirely self-contained in the dialect JAR — no changes to Rundeck's `application.groovy`, `rundeck-config.properties`, or any source file are required.

---

## Changes

- **`Oracle12cDialect` base** — fixes identity column support for Oracle 12c+
- **`OracleSessionFactoryBuilderFactory`** — registered via `META-INF/services`, applies the inspector only when `RundeckOracleDialect` is active
- **`OracleDistinctStatementInspector`** — rewrites `SELECT DISTINCT` → `SELECT` at the start of each SQL statement (anchored to `^\s*` to avoid matching inside string literals); deduplication falls back to Hibernate's in-memory transformer
- **CI updated to JDK 17** to match the Gradle 8.10 toolchain requirement
- **`@Override` annotations** added to pre-existing overrides

## Test plan

- [ ] Build passes (`./gradlew build`)
- [ ] Deploy against Oracle 12c+ (or 23c Free) — verify Rundeck starts without `IdentityColumnSupportImpl` errors
- [ ] Navigate to a job's "Referenced By" tab — verify no `ORA-22848` errors when querying executions with CLOB columns
- [ ] Run a workflow — verify execution completes without Oracle errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)