### PR TITLE
Upgrade base dialect from Oracle10gDialect to Oracle12cDialect; upgrade Gradle to 8.14.4 and Java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Get Fetch Tags
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: "!contains(github.ref, 'refs/tags')"
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ jar {
 }
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
     withSourcesJar()
     withJavadocJar()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
+++ b/src/main/java/org/rundeck/hibernate/RundeckOracleDialect.java
@@ -1,6 +1,6 @@
 package org.rundeck.hibernate;
 
-import org.hibernate.dialect.Oracle10gDialect;
+import org.hibernate.dialect.Oracle12cDialect;
 
 import java.sql.Types;
 
@@ -8,8 +8,9 @@ import java.sql.Types;
  * Custom Oracle dialect that fixes various issues with Oracle support in Hibernate.
  */
 public class RundeckOracleDialect
-        extends Oracle10gDialect
+        extends Oracle12cDialect
 {
+    @Override
     protected void registerLargeObjectTypeMappings() {
         registerColumnType(Types.BLOB, "blob");
         registerColumnType(Types.CLOB, "clob");
@@ -24,6 +25,7 @@ public class RundeckOracleDialect
         registerColumnType(Types.LONGVARBINARY, "blob");
     }
 
+    @Override
     protected void registerCharacterTypeMappings() {
         super.registerCharacterTypeMappings();
         registerColumnType(Types.VARCHAR, "varchar($l)");


### PR DESCRIPTION
## Changes

### 1. Upgrade base dialect from `Oracle10gDialect` to `Oracle12cDialect`

Replace `extends Oracle10gDialect` with `extends Oracle12cDialect` and add missing `@Override` annotations. No other behavior is changed — LOB type mappings and VARCHAR handling remain identical.

### 2. Upgrade Gradle wrapper to 8.14.4 and Java toolchain to 17

Aligns the build toolchain with the rundeckpro host project, which uses Gradle 8.14.4 and Java 17. The produced artifact requires **Java 17** at both build and runtime, which is consistent with Rundeck 6's own minimum requirement.

CI updated from JDK 11 to JDK 17 to match.

---

## Why Oracle12cDialect is required for Rundeck 6

Rundeck 6 fails to start against Oracle with:

```
org.hibernate.MappingException: org.hibernate.dialect.identity.IdentityColumnSupportImpl does not support identity key generation
    at org.hibernate.id.IdentityGenerator$BasicDelegate.getSelectSQL(IdentityGenerator.java:132)
    at rundeck.User.save(User.groovy)
```

This error occurs on the first login attempt (INSERT into the `RDUSER` table).

**Root cause:** During the Grails 7 / Hibernate 5.6 migration, `User.groovy` was updated to explicitly declare `id generator: 'identity'` in its GORM mapping:

```groovy
static mapping = {
    id generator: 'identity'  // Explicit id field required for Hibernate 5.6.15
}
```

The `identity` generator tells Hibernate to use the database's native identity column mechanism to retrieve the generated key after an INSERT. This calls `dialect.getIdentityColumnSupport().getIdentitySelectString()`.

- `Oracle10gDialect` returns `IdentityColumnSupportImpl` — the default no-op that **explicitly throws `MappingException`** on any identity key generation call
- `Oracle12cDialect` returns `Oracle12cIdentityColumnSupport`, which correctly retrieves the generated key using Oracle's `RETURNING ... INTO` mechanism

Additionally, Liquibase 4.x (Rundeck 6 uses 4.19.0) generates `GENERATED BY DEFAULT AS IDENTITY` for `autoIncrement: true` columns on Oracle 12c+. The schema itself has identity columns, which requires `Oracle12cIdentityColumnSupport` to work correctly.

## Why Oracle 11g compatibility is lost

`Oracle12cDialect` introduces SQL syntax changes that Oracle 11g does not support:

- **Pagination**: `Oracle12cDialect` generates `OFFSET ? ROWS FETCH NEXT ? ROWS ONLY`. Oracle 11g only supports `ROWNUM`-based pagination — every paginated query would fail with `ORA-00933`
- **Schema creation**: Liquibase 4.x generates `GENERATED BY DEFAULT AS IDENTITY` for Oracle 12c+. Oracle 11g does not support this DDL, so migrations fail before Hibernate is even reached

Oracle 11g support was already broken by the combination of Liquibase 4.x + the `id generator: 'identity'` mapping introduced in the Grails 7 migration. This change makes the minimum Oracle version requirement explicit in code.

## Test plan

- [ ] Build passes (`./gradlew build`)
- [ ] Deploy against Oracle 12c+ (or 23c Free) — verify Rundeck starts and login succeeds without `IdentityColumnSupportImpl` errors
- [ ] Verify paginated queries (job list, execution list) work correctly on Oracle 12c+

🤖 Generated with [Claude Code](https://claude.com/claude-code)