### PR TITLE
ci: update release workflow to Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
## Summary

- Updates `release.yml` to use Java 17 (Zulu distribution) instead of Java 11
- Aligns the release workflow with `gradle.yml` which already targets Java 17

## Test plan

- [ ] Verify the publish release workflow triggers correctly on tag push
- [ ] Confirm the Gradle build succeeds under Java 17 in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)