### PR TITLE
[RUN-4639] Publish Maven artifact to PackageCloud instead of Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Publish Release
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,10 +37,38 @@ jobs:
             build/libs/rundeck-oracle-dialect-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish Maven artifacts to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck/maven2}/org/rundeck/hibernate/rundeck-oracle-dialect/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/rundeck-oracle-dialect-${VERSION}.jar" "rundeck-oracle-dialect-${VERSION}.jar"
+          sign_and_upload "build/libs/rundeck-oracle-dialect-${VERSION}-sources.jar" "rundeck-oracle-dialect-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/rundeck-oracle-dialect-${VERSION}-javadoc.jar" "rundeck-oracle-dialect-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/rundeck-oracle-dialect/pom-default.xml" "rundeck-oracle-dialect-${VERSION}.pom"
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'groovy'
     id 'idea'
     alias(libs.plugins.axionRelease)
-    alias(libs.plugins.nexusPublish)
 }
 
 group = 'org.rundeck.hibernate'
@@ -57,16 +56,6 @@ java {
 
 repositories {
     mavenCentral()
-}
-
-nexusPublishing {
-    packageGroup = 'org.rundeck.hibernate'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/publishing.gradle"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,6 @@
 [versions]
 axionRelease = "1.18.17"
 groovy = "3.0.23"
-nexusPublish = "2.0.0"
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck/maven2").trim()
 
 publishing {
     publications {
@@ -38,16 +39,17 @@ publishing {
 
         }
     }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.findProperty("signingPassword"))
-        sign(publishing.publications)
+    repositories {
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4639](https://pagerduty.atlassian.net/browse/RUN-4639)

## Description

`org.rundeck` is over Maven Central's free publishing limits (RUN-4570); Sonatype begins rate-limiting publishing on 2026-08-11. This applies the same PackageCloud migration already validated end-to-end on the `rundeck-plugins` org repos (RUN-4638) and on `rundeck-cli` to this repo's single Maven module (`org.rundeck.hibernate:rundeck-oracle-dialect`).

- Removes the `nexus-publish` plugin and `nexusPublishing {}` block.
- Registers PackageCloud (`https://packagecloud.io/pagerduty/rundeck/maven2`) as the publishing repository in `gradle/publishing.gradle` — the same feed already used for `rundeck-cli`.
- Signs the artifact with the `gpg` CLI and uploads the signature via `curl` in `release.yml`, instead of Gradle's `signing` plugin: Gradle auto-generates a checksum for every publication artifact including `.asc` files, and PackageCloud's Maven endpoint 422s on the checksum-of-a-signature-file, aborting the publish task partway through.

**Impact check:** the sole dependent found via Maven Central usage data is `org.rundeck:rundeck` itself (this jar is bundled internally, e.g. `rundeckapp/build.gradle` in the `rundeckpro` repo pins `1.0.1`). No external third-party consumers found. Existing versions already published on Maven Central are unaffected — only future releases move to PackageCloud.

## Testing instructions

- `./gradlew clean build` passes locally (verified: `BUILD SUCCESSFUL`).
- `./gradlew tasks --all` confirms `publishAllPublicationsToPackageCloudRepository` exists.
- `./gradlew build` still succeeds with no `PKGCLD_REPO_URL`/`PKGCLD_WRITE_TOKEN` set (the fallback default in `publishing.gradle` avoids a null-URL crash for unrelated CI).
- To fully verify: push a test tag to trigger `release.yml`, confirm the jar (plus `-sources`/`-javadoc`/`.pom`) and its `.asc` signatures land under `https://packagecloud.io/pagerduty/rundeck/maven2/org/rundeck/hibernate/rundeck-oracle-dialect/`, and confirm `PKGCLD_WRITE_TOKEN`/`SIGNING_KEY_B64`/`SIGNING_PASSWORD` secrets are available to this workflow.


[RUN-4639]: https://pagerduty.atlassian.net/browse/RUN-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ